### PR TITLE
Add CortexJS calling conventions to If/Map/Filter/Reduce (v2.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.1.0] - 2026-08-19
+
+Continues the CortexJS compatibility pass: `If`, `Map`, `Filter`, and `Reduce` now also accept CortexJS calling conventions, alongside the existing Python-specific forms.
+
+### Fixed
+
+- **Correctness fix:** a locally-bound name (a `Constants` binding, a `Reduce` accumulator/current/index variable, or a `Function` parameter, see below) now correctly shadows a top-level solver parameter of the same name, instead of the global value silently winning. Previously `create_solver({"x": 5})` evaluating `["Constants", ["x", 100], ["Add", "x", 1]]` returned `6` instead of `101`. If you were unknowingly relying on the old (backwards) precedence, this will change your result.
+
+### Added
+
+- **`Function`**: now a real CortexJS-style lambda, `["Function", body, param1, param2, ...]`. With no parameter names, `body` can reference its arguments via the anonymous placeholders `"_"` (first argument only) and `"_1"`, `"_2"`, ... Meant to be passed as the function argument to `Map`, `Filter`, and `Reduce`; evaluated on its own it returns unevaluated. (Previously a non-functional stub that always returned `0`.)
+- **`If`**: now also accepts the CortexJS flat form, `["If", cond, then]` / `["If", cond, then, else]`, including the no-else form (returns `None`/CortexJS `Nothing` when the condition is false). The existing Python pair form, `["If", [cond, val], ..., else_val]`, is unchanged and detected automatically. (Note: a Python-form condition that is a bare parameter reference, e.g. `["If", ["my_flag", "yes"], "no"]`, is still correctly disambiguated — but wrapping such conditions in `IsTrue`/`IsFalse` remains the clearer style.)
+- **`Map` / `StrictMap` / `Filter`**: the function argument can now be a `["Function", ...]` expression (see above), in addition to the existing call-template form (e.g. `["Square"]`).
+- **`Reduce`**: now also accepts the CortexJS form, `["Reduce", collection, fn]` / `["Reduce", collection, fn, initial]`, where `fn` is applied as `fn(accumulator, current_item)` (call-template or `Function` form). Without an initial value, the first element seeds the accumulator. The existing 6-argument Python form (with named accumulator/current/index variables) is unchanged and detected automatically via argument count.
+- **`Product`**: `["Product", array]` multiplies together the numeric elements of `array`.
+
+[2.1.0]: https://github.com/LongenesisLtd/mathjson-solver/compare/v2.0.0...v2.1.0
+
 ## [2.0.0] - 2026-08-19
 
 Steers the solver back towards greater compatibility with [CortexJS MathJSON](https://cortexjs.io/compute-engine/), adding aliases and constructs that were previously CortexJS-only.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ except MathJSONException as e:
 solver(["Map", ["Array", 1, 2, 3, 4], ["Multiply"], 2])  # [2, 4, 6, 8]
 solver(["Reduce", ["Array", 1, 2, 3, 4], 0, ["Add", "acc", "item"],
         ["Variable", "acc"], ["Variable", "item"], ["Variable", "i"]])  # 10
+
+# CortexJS-style forms also work: a lambda via Function, and a 2-argument Reduce
+solver(["Map", ["Array", 1, 2, 3, 4], ["Function", ["Multiply", "_", 2]]])  # [2, 4, 6, 8]
+solver(["Reduce", ["Array", 1, 2, 3, 4], ["Add"]])                          # 10
 ```
 
 ## Supported Operations
@@ -74,9 +78,9 @@ The library supports a comprehensive set of mathematical operations:
 * **Comparison:** Equal, StrictEqual, NotEqual, Greater, GreaterEqual, Less, LessEqual
 * **Logic & Sets:** Any, All, Not, And, Or, Xor, Nand, Nor, Implies, Equivalent, In, NotIn, ContainsAnyOf, ContainsAllOf, ContainsNoneOf
 * **Statistics:** Average/Mean, Max, Min (both list and variadic forms), Median, Variance, StandardDeviation, Length/Count
-* **Functional Programming:** Map, Reduce, Filter
+* **Functional Programming:** Map/StrictMap, Reduce, Filter, Product (all also accept CortexJS calling conventions, including `Function` lambdas)
 * **Arrays:** Array/List creation, GenerateRange, Range, AtIndex, At, Slice, Appended, First, Last, Rest, Most, Reverse, Sort, Unique, Join, Zip, IsEmpty, CumulativeSum, CumulativeProduct
-* **Control Flow:** If statements, Switch-Case/Which, Constants definition
+* **Control Flow:** If statements (Python pair form and CortexJS flat form), Switch-Case/Which, Constants definition
 * **Type Conversion:** Int, Float, Str, IsDefined
 * **Date/Time:** Strptime, Strftime, Today, Now, TimeDelta functions (Weeks, Days, Hours, Minutes)
 * **Number Theory:** Chop, Mod, Clamp, GCD, LCM, Factorial, Binomial, IsPrime, Erf, Erfc

--- a/docs/README.md
+++ b/docs/README.md
@@ -405,6 +405,22 @@ else 9000
 
 `If` expressions do not need to be strictly _boolean_. Any value that is not _false_ are considered _true_.
 
+#### CortexJS flat form
+
+`If` also accepts the CortexJS flat form:
+
+```
+["If", <condition>, <then-expression>]
+["If", <condition>, <then-expression>, <else-expression>]
+```
+
+```python
+["If", ["Greater", "x", 3], 42, 99]   # 42 if x > 3, otherwise 99
+["If", ["Greater", "x", 3], 42]       # 42 if x > 3, otherwise None (CortexJS "Nothing")
+```
+
+The two forms are detected automatically: in the pair form, `s[1]` is always a `[condition, value]` pair; in the flat form, `s[1]` *is* the condition. This is unambiguous as long as a pair-form condition that happens to be a bare parameter reference is wrapped in `IsTrue`/`IsFalse` (the pattern already recommended above) rather than used bare, e.g. prefer `[["IsTrue", "my_flag"], "yes"]` over `["my_flag", "yes"]`.
+
 ### Switch-Case Statement
 ```
 ["Switch", <on-expression>, <default-result-expression>, [<case1-expression>, <result-expression>], ...],
@@ -629,7 +645,22 @@ Extracts a portion of an array between start and end indices (exclusive end).
 ```
 
 #### Reduce
-Reduces an array to a single value by iteratively applying a function that has access to an accumulator, current element, and index. This is a powerful functional programming construct that enables stateful computations over arrays.
+Reduces an array to a single value. Two calling conventions are supported, chosen automatically by argument count.
+
+**CortexJS form** (3 or 4 arguments):
+```python
+["Reduce", array, function]
+["Reduce", array, function, initial_value]
+```
+`function` is applied as `function(accumulator, current_item)` on each element; a call template (e.g. `["Add"]`) or a [`Function`](#function) expression can be used. Without `initial_value`, the first element seeds the accumulator.
+
+```python
+["Reduce", ["Array", 1, 2, 3, 4], ["Add"]]                                        # 10 (no initial value)
+["Reduce", ["Array", 1, 2, 3, 4], ["Function", ["Add", "_1", "_2"]], 0]           # 10
+["Reduce", ["Array", 1, 2, 3, 4], ["Function", ["Add", "acc", "n"], "acc", "n"], 0]  # 10
+```
+
+**Python form** (6 arguments): access to an accumulator, current element, *and* index — a powerful functional programming construct that enables stateful computations over arrays.
 
 **Syntax:**
 ```python
@@ -724,6 +755,13 @@ When building state tuples with multiple values, use the nested `Appended` patte
 ```
 
 This pattern can be extended for any number of state variables by adding more nested `Appended` calls.
+
+#### Product
+Multiplies together the numeric elements of an array.
+
+```python
+["Product", ["Array", 5, 7, 11]]                   # 385
+```
 
 #### Appended
 Appends a value to the end of an array, returning a new array with the added element.
@@ -1159,19 +1197,34 @@ Two-argument arctangent, `atan2(y, x)`, which correctly determines the quadrant 
 ## Advanced Functions
 
 ### Map
-Applies a function to each element of an array, returning a new array with the results. If the function fails for an element, the original element is preserved.
+Applies a function to each element of an array, returning a new array with the results. If the function fails for an element, the original element is preserved. `StrictMap` behaves the same but does not catch per-element failures.
+
+The `function` argument accepts two forms: the original "call template" (a construct name wrapped in a list, e.g. `["Square"]`, with any trailing arguments to `Map` appended on every call), or a CortexJS-style [`Function`](#function) expression.
 
 ```python
 ["Map", ["Array", 1, 2, 3], ["Square"]]                    # ["Array", 1, 4, 9]
 ["Map", ["Array", 1, 2, 3, None, "a"], ["Square"]]         # ["Array", 1, 4, 9, None, "a"]
 ["Map", ["Array", 1, 2, 3], ["Power"], 2]                  # ["Array", 1, 4, 9]
 ["Map", ["Array", 1, 2, 3], ["GreaterEqual"], 2]           # ["Array", False, True, True]
+
+# CortexJS Function form, anonymous placeholder
+["Map", ["Array", 1, 2, 3, 4], ["Function", ["Multiply", "_", 2]]]      # ["Array", 2, 4, 6, 8]
+# CortexJS Function form, named parameter
+["Map", ["Array", 1, 2, 3], ["Function", ["Add", "n", 1], "n"]]         # ["Array", 2, 3, 4]
 ```
 
 Complex example with aggregation:
 
 ```python
 ["Sum", ["Map", ["Array", 1, 2, 3, 4, 1, 1, 0, 1], ["GreaterEqual"], 2]]  # 3
+```
+
+### Filter
+Keeps only the elements of an array for which `function` evaluates truthy. Takes the same `function` argument forms as `Map` (call template or `Function` expression).
+
+```python
+["Filter", ["Array", 1, 2, 3], ["LessEqual"], 2]                            # ["Array", 1, 2]
+["Filter", ["Array", 1, 2, 3, 4, 5], ["Function", ["Greater", "_", 2]]]     # ["Array", 3, 4, 5]
 ```
 
 ### HasMatchingSublist
@@ -1290,7 +1343,25 @@ Finds the interval index where a value falls within a sorted array of bounds. Re
 ```
 
 ### Function
-**Note: This is a placeholder function for future implementation.** Currently not functional.
+Defines a CortexJS-style lambda:
+
+```
+["Function", body_expression, param_name1, param_name2, ...]
+```
+
+`body_expression` is evaluated with the given parameter names bound to whatever arguments the function is called with. `Function` expressions are meant to be passed as the `function` argument of [`Map`](#map), [`Filter`](#filter), and [`Reduce`](#reduce), which call them with 1 argument (the element) or 2 (accumulator, current item) respectively.
+
+If no parameter names are given, the anonymous placeholders `"_"` (bound only when there is a single argument) and `"_1"`, `"_2"`, ... (always bound, in order) are used instead:
+
+```python
+["Function", ["Multiply", "_", 2]]           # body refers to its single argument as "_"
+["Function", ["Add", "_1", "_2"]]            # body refers to two arguments as "_1" and "_2"
+["Function", ["Add", "acc", "n"], "acc", "n"]  # named parameters
+```
+
+Evaluating a `["Function", ...]` expression outside of such a context (i.e. not consumed by `Map`/`Filter`/`Reduce`) just returns it unevaluated.
+
+**Note:** a parameter name bound inside a `Function` body correctly shadows a top-level solver parameter of the same name.
 
 ---
 
@@ -1353,7 +1424,7 @@ Finds the interval index where a value falls within a sorted array of bounds. Re
 
 ### Control Flow
 - [Constants](#constants) - Define constants
-- [If](#if-statement) - Conditional statements
+- [If](#if-statement) - Conditional statements (Python pair form and CortexJS flat form)
 - [Switch / Which](#switch-case-statement) - Switch-case statements
 
 ### Arrays and Aggregation
@@ -1377,7 +1448,8 @@ Finds the interval index where a value falls within a sorted array of bounds. Re
 - [Slice](#slice) - Extract array portion
 - [CumulativeProduct](#cumulativeproduct) - Cumulative product calculation
 - [CumulativeSum](#cumulativesum) - Cumulative sum calculation
-- [Reduce](#reduce) - Reduce array to single value with accumulator
+- [Reduce](#reduce) - Reduce array to single value (CortexJS `fn` form or Python accumulator form)
+- [Product](#product) - Multiply array elements together
 - [Appended](#appended) - Append value to array
 
 ### Boolean and Set Operations
@@ -1427,11 +1499,12 @@ Finds the interval index where a value falls within a sorted array of bounds. Re
 - [Pi, Degrees, ExponentialE, GoldenRatio](#constants) - Constants
 
 ### Advanced Functions
-- [Map](#map) - Apply function to array elements
+- [Map / StrictMap](#map) - Apply function to array elements
+- [Filter](#filter) - Keep array elements matching a condition
 - [HasMatchingSublist](#hasmatchingsublist) - Advanced sublist matching
 
 ### Integration Functions
-- [Function](#function) - Function definition (placeholder)
+- [Function](#function) - CortexJS-style lambda, for use with Map/Filter/Reduce
 - [Variable](#variable) - Variable reference
 - [TrapezoidalIntegrate](#trapezoidalintegrate) - Numerical integration
 - [Interp](#interp) - Linear interpolation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mathjson-solver"
-version = "2.0.0"
+version = "2.1.0"
 authors = [{name = "Martins Mednis", email = "mrt@mednis.info"}]
 description = "Utilities for MathJSON evaluation"
 readme = "README.md"

--- a/src/mathjson_solver/__main__.py
+++ b/src/mathjson_solver/__main__.py
@@ -605,6 +605,32 @@ def create_mathjson_solver(solver_parameters):
             def If(s):
                 if len(s) < 3:
                     raise ValueError("Wrong parameters for 'If'")
+
+                # Detect the CortexJS flat form: ["If", cond, then] or
+                # ["If", cond, then, else]. In the Python pair-form below,
+                # s[1] is always a [condition, value] pair whose first
+                # element (the condition) is itself a MathJSON construct
+                # call, e.g. ["Equal", 1, 0]. A CortexJS flat condition is
+                # either not a list at all, or is itself such a construct
+                # call (its own first element is a *known construct name*).
+                # Requiring a known name - rather than any string - keeps a
+                # Python-form condition that is a bare parameter reference,
+                # e.g. ["If", ["my_flag", "yes"], "no"], from being
+                # misdetected as CortexJS form.
+                is_cortexjs_form = not isinstance(s[1], list) or (
+                    bool(s[1]) and isinstance(s[1][0], str) and s[1][0] in constructs
+                )
+
+                if is_cortexjs_form:
+                    if len(s) not in (3, 4):
+                        raise ValueError("Wrong parameters for 'If'")
+                    if f(s[1], c):
+                        return f(s[2], c)
+                    elif len(s) == 4:
+                        return f(s[3], c)
+                    else:
+                        return None  # CortexJS: Nothing, no else and condition false
+
                 for x in s[1:-1]:
                     if len(x) != 2:
                         raise ValueError("Wrong if or elif in 'If'")
@@ -677,20 +703,56 @@ def create_mathjson_solver(solver_parameters):
             def Not(s):
                 return not f(s[1])
 
+            def _apply_fn(fn_expr, args):
+                """
+                Apply a "function" argument (as used by Map, Filter, and the
+                CortexJS form of Reduce) to positional `args`. Supports two
+                conventions:
+
+                - CortexJS `["Function", body, param1, param2, ...]`. If no
+                  parameter names are given, `args` are bound to the
+                  anonymous placeholders "_" (only when there is a single
+                  argument) and "_1", "_2", ... (always), for use inside
+                  `body`.
+                - The existing "call template" convention:
+                  `[function_name, ...]`, applied as
+                  `f([function_name] + args, c)`.
+                """
+                if isinstance(fn_expr, list) and fn_expr and fn_expr[0] == "Function":
+                    body = fn_expr[1]
+                    params = fn_expr[2:]
+                    local_c = dict(c)
+                    if params:
+                        for name, value in zip(params, args):
+                            local_c[name] = value
+                    else:
+                        if len(args) == 1:
+                            local_c["_"] = args[0]
+                        for i, value in enumerate(args, start=1):
+                            local_c[f"_{i}"] = value
+                    return f(body, local_c)
+                elif isinstance(fn_expr, list) and fn_expr:
+                    function_name = fn_expr[0]
+                    return f([function_name] + list(args), c)
+                else:
+                    raise ValueError(
+                        "Wrong function parameter: expected a call template "
+                        "(e.g. ['Square']) or a ['Function', body, ...] expression."
+                    )
+
             def Map(s):
                 """
                 ["Map", list, function, more parameters]
                 The `function` must accept at least one parameter. That is for the current loop element.
                 The `more parameters` are for any additional parameters that function might have.
+                `function` can also be a CortexJS ["Function", body, ...params] expression.
                 """
                 z = f(s[1], c)
                 if isinstance(z, list):
                     retlist = ["Array"]
                     for x in z[1:]:
                         try:
-                            the_function_name = s[2][0]
-                            ss = [the_function_name, x] + s[3:]
-                            retlist.append(f(ss, c))
+                            retlist.append(_apply_fn(s[2], [x] + s[3:]))
                         except MathJSONException:
                             retlist.append(x)
                     return retlist
@@ -700,14 +762,13 @@ def create_mathjson_solver(solver_parameters):
                 ["Map", list, function, more parameters]
                 The `function` must accept at least one parameter. That is for the current loop element.
                 The `more parameters` are for any additional parameters that function might have.
+                `function` can also be a CortexJS ["Function", body, ...params] expression.
                 """
                 z = f(s[1], c)
                 if isinstance(z, list):
                     retlist = ["Array"]
                     for x in z[1:]:
-                        the_function_name = s[2][0]
-                        ss = [the_function_name, x] + s[3:]
-                        retlist.append(f(ss, c))
+                        retlist.append(_apply_fn(s[2], [x] + s[3:]))
                     return retlist
 
             def Filter(s):
@@ -715,14 +776,13 @@ def create_mathjson_solver(solver_parameters):
                 ["Filter", list, function, more parameters]
                 The `function` must accept at least one parameter. That is for the current loop element.
                 The `more parameters` are for any additional parameters that function might have.
+                `function` can also be a CortexJS ["Function", body, ...params] expression.
                 """
                 z = f(s[1], c)
                 if isinstance(z, list):
                     retlist = ["Array"]
                     for x in z[1:]:
-                        the_function_name = s[2][0]
-                        ss = [the_function_name, x] + s[3:]
-                        if f(ss, c):
+                        if _apply_fn(s[2], [x] + s[3:]):
                             retlist.append(x)
                     return retlist
 
@@ -885,14 +945,17 @@ def create_mathjson_solver(solver_parameters):
 
             def Function(s):
                 """
-                ["Function", function_expression, parameters]
-                The `function_name` must be a callable function.
-                The `parameters` are the arguments to be passed to the function.
+                ["Function", body_expression, param_name1, param_name2, ...]
+                Defines a CortexJS-style lambda: `body_expression` is evaluated
+                with the given parameter names bound to whatever arguments it
+                is called with. `Function` expressions are meant to be passed
+                as the `function` argument of Map, Filter, and Reduce; if no
+                parameter names are given, the anonymous placeholders "_",
+                "_1", "_2", ... are used instead (see those functions).
+                Evaluating a ["Function", ...] expression outside of such a
+                context just returns it unevaluated.
                 """
-                function_expression = s[1]
-                arguments = s[2:]
-                return 0
-                # return f(function_expression, c) function_name(*parameters)
+                return s
 
             def MultiplyByScalar(s):
                 """
@@ -1135,8 +1198,42 @@ def create_mathjson_solver(solver_parameters):
 
             def Reduce(s):
                 """
+                Two calling conventions, disambiguated by argument count:
+
+                CortexJS form (3 or 4 arguments):
+                ["Reduce", list, function]
+                ["Reduce", list, function, initial_value]
+                `function` is applied as `function(accumulator, current_item)`
+                on each element; without `initial_value`, the first element
+                seeds the accumulator. `function` can be a call template
+                (e.g. ["Add"]) or a ["Function", body, ...params] expression
+                (see `_apply_fn`).
+
+                Original Python form (6 arguments):
                 ["Reduce", list, initial_value, function, str_name_of_accumulator, str_name_of_current, str_name_of_index]
                 """
+                if len(s) <= 4:
+                    the_list = f(s[1], c)
+                    if not (isinstance(the_list, list) and the_list[0] == "Array"):
+                        raise ValueError("Parameter 1 must be an array.")
+                    elements = the_list[1:]
+                    fn_expr = s[2]
+
+                    if len(s) == 4:
+                        accumulator = f(s[3], c)
+                        remaining = elements
+                    else:
+                        if not elements:
+                            raise ValueError(
+                                "'Reduce' on an empty collection requires an initial value."
+                            )
+                        accumulator = f(elements[0], c)
+                        remaining = elements[1:]
+
+                    for x in remaining:
+                        accumulator = _apply_fn(fn_expr, [accumulator, x])
+                    return accumulator
+
                 the_list = f(s[1], c)[1:]
                 initial_value = f(s[2], c)
                 function_expression = s[3]
@@ -1158,6 +1255,19 @@ def create_mathjson_solver(solver_parameters):
                     c[name_accumulator] = f(function_expression, c)
 
                 return c[name_accumulator]
+
+            def Product(s):
+                """
+                ["Product", array]
+                Multiplies together the numeric elements of `array`.
+                """
+                the_list = f(s[1], c)
+                if not (isinstance(the_list, list) and the_list[0] == "Array"):
+                    raise ValueError("Parameter 1 must be an array.")
+                result = 1
+                for x in the_list[1:]:
+                    result *= f(x, c)
+                return result
 
             def Appended(s):
                 """
@@ -1291,6 +1401,7 @@ def create_mathjson_solver(solver_parameters):
                 "FindIntervalIndex": FindIntervalIndex,
                 "TrapezoidalIntegrate": TrapezoidalIntegrate,
                 "Reduce": Reduce,
+                "Product": Product,
                 "Appended": Appended,
                 "Sin": Sin,
                 "Cos": Cos,
@@ -1385,13 +1496,16 @@ def create_mathjson_solver(solver_parameters):
                 #     NotImplementedError(f"'{s[0]}' is not supported"), s
                 # )
                 return s
+        elif s in c:
+            # Local scope (Constants, Reduce accumulator/current/index,
+            # Function parameters, ...) shadows top-level solver parameters
+            # of the same name, matching normal lexical scoping.
+            return f(c[s], c)
         elif s in solver_parameters:
             try:
                 return f(solver_parameters[s], c)
             except RecursionError:
                 return solver_parameters[s]
-        elif s in c:
-            return f(c[s], c)
         else:
             # raise KeyError(f"Parameter '{s}' is not defined")
             return s
@@ -1489,6 +1603,7 @@ def extract_variables(s: Union[list, int, float, str], li: set, ignore_list: set
         "TrapezoidalIntegrate",
         "TrapezoidalIntegrate",
         "Reduce",
+        "Product",
         "Appended",
         "Sin",
         "Cos",
@@ -1571,10 +1686,37 @@ def extract_variables(s: Union[list, int, float, str], li: set, ignore_list: set
                 li.update(extract_variables(x[1], li, ignore_list))
             li.update(extract_variables(s[-1], li, ignore_list))
         elif s[0] == "If":
-            for elif_block in s[1:-1]:  # s[1] is list
-                for x in elif_block:
+            # Mirror the calling-convention detection used by the solver's
+            # own `If` (see its docstring / comments): CortexJS flat form
+            # ["If", cond, then[, else]] vs. the Python pair form
+            # ["If", [cond, val], ..., else_val].
+            is_cortexjs_form = len(s) > 1 and (
+                not isinstance(s[1], list)
+                or (
+                    bool(s[1])
+                    and isinstance(s[1][0], str)
+                    and s[1][0] in constructs
+                )
+            )
+            if is_cortexjs_form:
+                for x in s[1:]:
                     li.update(extract_variables(x, li, ignore_list))
-            li.update(extract_variables(s[-1], li, ignore_list))
+            else:
+                for elif_block in s[1:-1]:  # s[1] is list
+                    for x in elif_block:
+                        li.update(extract_variables(x, li, ignore_list))
+                li.update(extract_variables(s[-1], li, ignore_list))
+        elif s[0] == "Function":
+            # ["Function", body, param1, param2, ...]: parameter names (and
+            # the anonymous placeholders "_", "_1", "_2", ...) are bound
+            # locally, not free variables.
+            for p in s[2:]:
+                if isinstance(p, str):
+                    ignore_list.add(p)
+            ignore_list.update({f"_{i}" for i in range(1, 10)})
+            ignore_list.add("_")
+            if len(s) > 1:
+                li.update(extract_variables(s[1], li, ignore_list))
         else:
             for x in s[1:]:
                 li.update(extract_variables(x, li, ignore_list))

--- a/tests/test_cortexjs_tier3.py
+++ b/tests/test_cortexjs_tier3.py
@@ -1,0 +1,158 @@
+import sys
+import os
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "../src/"))
+
+from mathjson_solver import create_solver, extract_variables
+
+
+# --- If: CortexJS flat form, alongside the existing Python pair form ---
+
+
+@pytest.mark.parametrize(
+    "parameters, expression, expected_result",
+    [
+        ({"x": 5}, ["If", ["Greater", "x", 3], 42, 99], 42),
+        ({"x": 1}, ["If", ["Greater", "x", 3], 42, 99], 99),
+        ({"x": 5}, ["If", ["Greater", "x", 3], 42], 42),
+        ({"x": 1}, ["If", ["Greater", "x", 3], 42], None),
+        (
+            {},
+            ["If", [["Equal", 1, 0], 10], [["Equal", 2, 2], 20], 9000],
+            20,
+        ),
+        # A Python-pair condition that is a bare parameter reference is
+        # still correctly disambiguated from the CortexJS flat form.
+        ({"my_flag": True}, ["If", ["my_flag", "yes"], "no"], "yes"),
+        ({"my_flag": False}, ["If", ["my_flag", "yes"], "no"], "no"),
+    ],
+)
+def test_if_forms(parameters, expression, expected_result):
+    solver = create_solver(parameters)
+    assert solver(expression) == expected_result
+
+
+def test_if_cortexjs_form_requires_valid_arity():
+    solver = create_solver({})
+    with pytest.raises(Exception):
+        solver(["If", ["Greater", 1, 0]])
+
+
+# --- Function / Map / Filter / Reduce: CortexJS lambda form ---
+
+
+@pytest.mark.parametrize(
+    "parameters, expression, expected_result",
+    [
+        (
+            {},
+            ["Map", ["Array", 1, 2, 3, 4], ["Function", ["Multiply", "_", 2]]],
+            ["Array", 2.0, 4.0, 6.0, 8.0],
+        ),
+        (
+            {},
+            ["Map", ["Array", 1, 2, 3], ["Function", ["Add", "n", 1], "n"]],
+            ["Array", 2.0, 3.0, 4.0],
+        ),
+        # Legacy call-template form keeps working unchanged.
+        ({}, ["Map", ["Array", 1, 2, 3], ["Square"]], ["Array", 1, 4, 9]),
+        (
+            {},
+            ["Filter", ["Array", 1, 2, 3, 4, 5], ["Function", ["Greater", "_", 2]]],
+            ["Array", 3, 4, 5],
+        ),
+        ({}, ["Filter", ["Array", 1, 2, 3], ["LessEqual"], 2], ["Array", 1, 2]),
+        (
+            {},
+            ["Reduce", ["Array", 1, 2, 3, 4], ["Function", ["Add", "_1", "_2"]]],
+            10.0,
+        ),
+        (
+            {},
+            [
+                "Reduce",
+                ["Array", 1, 2, 3, 4],
+                ["Function", ["Add", "acc", "n"], "acc", "n"],
+                0,
+            ],
+            10.0,
+        ),
+        ({}, ["Reduce", ["Array", 1, 2, 3, 4], ["Add"]], 10.0),
+        (
+            {},
+            [
+                "Reduce",
+                ["Array", 1, 2, 3, 4],
+                0,
+                ["Add", "accumulator", "current_item"],
+                ["Variable", "accumulator"],
+                ["Variable", "current_item"],
+                ["Variable", "index"],
+            ],
+            10.0,
+        ),
+        ({}, ["Product", ["Array", 5, 7, 11]], 385),
+    ],
+)
+def test_function_map_filter_reduce(parameters, expression, expected_result):
+    solver = create_solver(parameters)
+    assert solver(expression) == expected_result
+
+
+def test_bare_function_expression_returns_unevaluated():
+    solver = create_solver({})
+    assert solver(["Function", ["Multiply", "_", 2]]) == [
+        "Function",
+        ["Multiply", "_", 2],
+    ]
+
+
+# --- Local scope correctly shadows top-level solver parameters ---
+
+
+def test_constants_shadow_solver_parameter():
+    solver = create_solver({"x": 5})
+    assert solver(["Constants", ["x", 100], ["Add", "x", 1]]) == 101.0
+
+
+def test_reduce_variable_shadows_solver_parameter():
+    solver = create_solver({"x": 5})
+    result = solver(
+        [
+            "Reduce",
+            ["Array", 1, 2, 3, 4],
+            0,
+            ["Add", "accumulator", "x"],
+            ["Variable", "accumulator"],
+            ["Variable", "x"],
+            ["Variable", "index"],
+        ]
+    )
+    assert result == 10.0
+
+
+def test_function_parameter_shadows_solver_parameter():
+    solver = create_solver({"x": 5})
+    result = solver(["Map", ["Array", 1, 2, 3], ["Function", ["Add", "x", 1], "x"]])
+    assert result == ["Array", 2.0, 3.0, 4.0]
+
+
+# --- extract_variables ---
+
+
+def test_extract_variables_if_cortexjs_form():
+    result = extract_variables(["If", ["Greater", "x", 3], "y", "z"], set(), set())
+    assert result == {"x", "y", "z"}
+
+
+def test_extract_variables_if_python_pair_bare_flag():
+    result = extract_variables(["If", ["my_flag", "y"], "z"], set(), set())
+    assert result == {"my_flag", "y", "z"}
+
+
+def test_extract_variables_function_params_are_not_free_variables():
+    result = extract_variables(
+        ["Map", "arr", ["Function", ["Add", "acc", "extra"], "acc"]], set(), set()
+    )
+    assert result == {"arr", "extra"}


### PR DESCRIPTION
## Summary

Completes the CortexJS compatibility pass: `If`, `Map`, `Filter`, and `Reduce` now also accept CortexJS calling conventions, alongside the existing Python-specific forms. The two forms are disambiguated automatically — by argument shape for `If`, by argument count for `Reduce` — with no change required to existing expressions.

## Added

- **`Function`** is now a real CortexJS-style lambda: `["Function", body, param1, param2, ...]`, with anonymous `"_"`/`"_1"`/`"_2"` placeholders when no parameter names are given. Previously a non-functional stub that always returned `0`.
- **`If`** accepts the CortexJS flat form: `["If", cond, then[, else]]`, including a no-else form that returns `None`/`Nothing`.
- **`Map`**, **`StrictMap`**, and **`Filter`** accept a `Function` expression as their function argument, alongside the existing call-template form.
- **`Reduce`** accepts `["Reduce", collection, fn[, initial]]`, applying `fn` as `fn(accumulator, current_item)`. The existing 6-argument Python form (named accumulator/current/index variables) is unchanged.
- **`Product`**: `["Product", array]` multiplies array elements together.
- `Filter` and `StrictMap`, previously undocumented, now have docs.

## Fixed

- **Correctness bug (pre-existing, not introduced by this PR):** a locally-bound name (`Constants`, `Reduce` accumulator/current/index, or now `Function` parameters) now correctly shadows a top-level solver parameter of the same name, instead of the global value silently winning:
  ```python
  create_solver({"x": 5})(["Constants", ["x", 100], ["Add", "x", 1]])
  # was 6, now 101
  ```
  Confirmed present before this PR. Directly affects anyone who names a local binding the same as a solver parameter — worth a careful look if you rely on that pattern.

## Disambiguation notes

- `If`: the Python pair form's `s[1]` is always a `[condition, value]` pair; the CortexJS form's `s[1]` *is* the condition. Detection requires the condition's head to be a known construct name (not just any string) to avoid misreading a bare parameter reference as CortexJS form — e.g. `["If", ["my_flag", "yes"], "no"]` still resolves correctly. See code comments and the docs for the one residual edge case.
- `Reduce`: disambiguated purely by argument count (3–4 args = CortexJS, 7 args = Python form), no shape-sniffing needed.

## Testing

- All existing tests pass unchanged.
- New `tests/test_cortexjs_tier3.py` covers both `If` forms (including the bare-parameter edge case), `Function`/`Map`/`Filter`/`Reduce` CortexJS forms alongside the legacy forms, `Product`, and the parameter-shadowing fix.