### PR TITLE
Fix sdist packaging leak (v2.1.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,9 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Scratch space for working notes; never intended for the published package
+untracked/
+
+# Local Claude Code settings (machine-specific)
+.claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.1.1] - 2026-08-19
+
+### Fixed
+
+- Fixed packaging: the sdist now only includes the intended package, tests, docs, and metadata files.
+
+[2.1.1]: https://github.com/LongenesisLtd/mathjson-solver/compare/v2.1.0...v2.1.1
+
 ## [2.1.0] - 2026-08-19
 
 Continues the CortexJS compatibility pass: `If`, `Map`, `Filter`, and `Reduce` now also accept CortexJS calling conventions, alongside the existing Python-specific forms.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mathjson-solver"
-version = "2.1.0"
+version = "2.1.1"
 authors = [{name = "Martins Mednis", email = "mrt@mednis.info"}]
 description = "Utilities for MathJSON evaluation"
 readme = "README.md"
@@ -18,3 +18,24 @@ classifiers = [
 [project.urls]
 Homepage = "https://github.com/LongenesisLtd/mathjson-solver"
 "Bug Tracker" = "https://github.com/LongenesisLtd/mathjson-solver/issues"
+
+[tool.hatch.build.targets.sdist]
+# Explicit allowlist: hatchling's default sdist selection includes any file
+# not gitignored, tracked or not, which previously leaked the (gitignored-
+# but-not-excluded) untracked/ scratch directory and local Claude Code
+# settings into the published package.
+include = [
+    "/src",
+    "/tests",
+    "/docs",
+    "/README.md",
+    "/CHANGELOG.md",
+    "/LICENSE",
+    "/CONTRIBUTING.md",
+    "/CODE_OF_CONDUCT.md",
+    "/SECURITY.md",
+    "/pyproject.toml",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/mathjson_solver"]


### PR DESCRIPTION
## Summary

Fixes packaging: `hatchling`'s default sdist file selection includes anything not gitignored, regardless of git tracking status. This meant the published sdist (`.tar.gz`) bundled the entire working directory, including the untracked scratch directory and local Claude Code settings.

Adds an explicit `[tool.hatch.build.targets.sdist]` include list and gitignores the scratch directory. The sdist now contains only the intended package, tests, docs, and metadata files (50KB, down from ~13.8MB). The wheel (`.whl`) was never affected — it only ever contained the package code.

Bumped to 2.1.1 (packaging-only fix, no library behavior change).

## Testing

- `python -m build` produces a clean sdist and wheel; verified contents with `tar -tzf` / `unzip -l`.
- `twine check dist/*` passes.
- Full test suite passes (416 tests).